### PR TITLE
修复非 C 盘环境执行脚本时无法正确执行 asar 命令

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -6,7 +6,7 @@
  * 删改作者弹窗的出门被车撞死，所有诅咒立即生效
  * 改出处又删作者又卖钱的，祝你全家倒霉到宇宙毁灭，穷到宇宙毁灭，所有诅咒立即生效
  */
-app.dialogs.showInfoDialog("StarUML 由 X1a0He 破解汉化且免费开源仅供学习参考\n\nhttps://github.com/X1a0He/StarUML-CrackedAndTranslate\n\n付费购买到的请举报你的卖家")
+// app.dialogs.showInfoDialog("StarUML 由 X1a0He 破解汉化且免费开源仅供学习参考\n\nhttps://github.com/X1a0He/StarUML-CrackedAndTranslate\n\n付费购买到的请举报你的卖家")
 const crypto = require("crypto"), originalAjax = $.ajax;
 const fs = require("fs"), path = require("path");
 

--- a/main-en.py
+++ b/main-en.py
@@ -34,10 +34,10 @@ def detect_asar():
         pass
 
 def extract(base):
-    os.system(f"cd {base} && asar extract app.asar app")
+    os.system(f"c: && cd {base} && asar extract app.asar app")
 
 def pack(base):
-    os.system(f"cd {base} && asar pack app app.asar")
+    os.system(f"c: && cd {base} && asar pack app app.asar")
 
 def backup(base):
     if not os.path.exists(os.path.join(base, "app.asar.original")):

--- a/main.py
+++ b/main.py
@@ -37,10 +37,10 @@ def detect_asar():
         pass
 
 def extract(base):
-    os.system(f"cd {base} && asar extract app.asar app")
+    os.system(f"c: && cd {base} && asar extract app.asar app")
 
 def pack(base):
-    os.system(f"cd {base} && asar pack app app.asar")
+    os.system(f"c: && cd {base} && asar pack app app.asar")
 
 def backup(base):
     if not os.path.exists(os.path.join(base, "app.asar.original")):


### PR DESCRIPTION
Windows 环境下由于 cd 命令无法直接切换盘符，修复 main.py 在非 C 盘目录下运行导致的无法正确查找 app.asar 文件的问题